### PR TITLE
chore: デバッグ時に`./examples`が開かれるように設定した

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -12,7 +12,8 @@
       "request": "launch",
       "args": [
         "--extensionDevelopmentPath=${workspaceFolder}",
-        "--extensionDevelopmentKind=web"
+        "--extensionDevelopmentKind=web",
+        "${workspaceFolder}/examples"
       ],
       "outFiles": ["${workspaceFolder}/dist/web/**/*.js"],
       "preLaunchTask": "Watch Web"


### PR DESCRIPTION
fix #19