### PR TITLE
fix: Book の プレビュー画面にてサマリー項目が zenn-cli と異なる問題を修正

### DIFF
--- a/package.json
+++ b/package.json
@@ -187,7 +187,6 @@
     "js-yaml": "^4.1.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "yaml": "^2.1.1",
     "zenn-content-css": "^0.1.134",
     "zenn-embed-elements": "^0.1.134",
     "zenn-markdown-html": "^0.1.134",

--- a/package.json
+++ b/package.json
@@ -151,6 +151,7 @@
   },
   "devDependencies": {
     "@svgr/webpack": "^6.3.1",
+    "@types/js-yaml": "^4.0.5",
     "@types/mocha": "^9.1.1",
     "@types/react": "^18.0.15",
     "@types/react-dom": "^18.0.6",
@@ -183,6 +184,7 @@
   },
   "dependencies": {
     "emoji-regex": "^10.2.1",
+    "js-yaml": "^4.1.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "yaml": "^2.1.1",

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -6,7 +6,7 @@
  * ===================================================================
  */
 
-import { parse as parseYaml } from "yaml";
+import { load as parseYaml } from "js-yaml";
 
 import { FRONT_MATTER_PATTERN, PUBLISHED_AT_PATTERN } from "./patterns";
 
@@ -44,7 +44,7 @@ export const parseFrontMatter = (
   text: string
 ): { [key: string]: string | undefined } => {
   const meta = FRONT_MATTER_PATTERN.exec(text)?.[2];
-  const result = meta ? parseYaml(meta) : {};
+  const result = meta ? (parseYaml(meta) as any) : {};
 
   if (typeof result !== "object") return {};
   if (Array.isArray(result)) return {};

--- a/src/webviews/src/components/BookPreview/BookPreview.module.scss
+++ b/src/webviews/src/components/BookPreview/BookPreview.module.scss
@@ -49,6 +49,7 @@
 
 .headerPropertyValue {
   flex: 1;
+  white-space: pre-line;
 }
 
 .topic {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1252,6 +1252,11 @@
   resolved "https://registry.yarnpkg.com/@types/estree/-/estree-0.0.51.tgz#cfd70924a25a3fd32b218e5e420e6897e1ac4f40"
   integrity sha512-CuPgU6f3eT/XgKKPqKd/gLZV1Xmvf1a2R5POBOGQa6uv82xpls89HU5zKeVoyR8XzHd1RGNOlQlvUe3CFkjWNQ==
 
+"@types/js-yaml@^4.0.5":
+  version "4.0.5"
+  resolved "https://registry.yarnpkg.com/@types/js-yaml/-/js-yaml-4.0.5.tgz#738dd390a6ecc5442f35e7f03fa1431353f7e138"
+  integrity sha512-FhpRzf927MNQdRZP0J5DLIdTXhjLYzeUTmLAu69mnVksLH9CJY3IuSeEgbKUki7GQZm0WqDkGzyxju2EZGD2wA==
+
 "@types/json-schema@*", "@types/json-schema@^7.0.8", "@types/json-schema@^7.0.9":
   version "7.0.11"
   resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.11.tgz#d421b6c527a3037f7c84433fd2c4229e016863d3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5853,11 +5853,6 @@ yaml@^1.10.0:
   resolved "https://registry.yarnpkg.com/yaml/-/yaml-1.10.2.tgz#2301c5ffbf12b467de8da2333a459e29e7920e4b"
   integrity sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==
 
-yaml@^2.1.1:
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/yaml/-/yaml-2.1.1.tgz#1e06fb4ca46e60d9da07e4f786ea370ed3c3cfec"
-  integrity sha512-o96x3OPo8GjWeSLF+wOAbrPfhFOGY0W00GNaxCDv+9hkcDJEnev1yh8S7pgHF0ik6zc8sQLuL8hjHjJULZp8bw==
-
 yargs-parser@20.2.4:
   version "20.2.4"
   resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-20.2.4.tgz#b42890f14566796f85ae8e3a25290d205f154a54"


### PR DESCRIPTION
## :bookmark_tabs: Summary

Bookのプレビュー画面にてサマリーの項目が複数行に渡る文字列で改行などを含む場合に zenn-cli や web 上での表示と異なる問題を修正しました。ただし、yaml パッケージを js-yaml に置き換えたのでそこについては問題があるかもしれません。

Resolves #49 

### :clipboard: Tasks

- [x] :book: [Contribution Guide](https://github.com/zenn-dev/zenn-vscode-extension/blob/main/CONTRIBUTING.md) を読んだ
- [x] :woman_technologist: `canary` ブランチに対するプルリクエストである
- [x] 実行して正しく動作しているか確認する
- [x] 不要なコードが含まれていないか( コメントやログの消し忘れに注意 )
- [x] XSS になるようなコードが含まれていないか
- [x] Pull Reuqest の内容は妥当か( 膨らみすぎてないか )
