### PR TITLE
fix: js-yamlに変えたことによる型エラーを修正

### DIFF
--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -10,6 +10,14 @@ import { load as parseYaml } from "js-yaml";
 
 import { FRONT_MATTER_PATTERN, PUBLISHED_AT_PATTERN } from "./patterns";
 
+declare module "js-yaml" {
+  /**
+   * デフォルトの返り値の型が unknown なので Lint エラーが出る。
+   * それを回避するために any 型に上書きする
+   */
+  function load(str: string, opts?: LoadOptions): any;
+}
+
 export { parseYaml };
 
 /**
@@ -44,7 +52,7 @@ export const parseFrontMatter = (
   text: string
 ): { [key: string]: string | undefined } => {
   const meta = FRONT_MATTER_PATTERN.exec(text)?.[2];
-  const result = meta ? (parseYaml(meta) as any) : {};
+  const result = meta ? parseYaml(meta) : {};
 
   if (typeof result !== "object") return {};
   if (Array.isArray(result)) return {};


### PR DESCRIPTION
## :bookmark_tabs: Summary

js-yaml の `load()` は返り値の型が unknown なため、そのまま使用すると型エラーが発生して `yarn lint` に失敗する。
なので、`declare module` を使って型を上書きするように修正した。

### :clipboard: Tasks

プルリクエストを作成いただく際、お手数ですが以下の内容についてご確認をお願いします。

- [x] :book: [Contribution Guide](https://github.com/zenn-dev/zenn-vscode-extension/blob/main/CONTRIBUTING.md) を読んだ
- [x] :woman_technologist: `canary` ブランチに対するプルリクエストである
- [x] 実行して正しく動作しているか確認する
- [x] 不要なコードが含まれていないか( コメントやログの消し忘れに注意 )
- [x] XSS になるようなコードが含まれていないか
- [x] Pull Reuqest の内容は妥当か( 膨らみすぎてないか )

より詳しい内容は [Pull Request Policy](https://github.com/zenn-dev/zenn-vscode-extension/blob/main/docs/pull_request_policy.md) を参照してください。
