### PR TITLE
feat: チャプターの新規作成コマンドの追加

### DIFF
--- a/package.json
+++ b/package.json
@@ -123,9 +123,14 @@
       ],
       "view/item/context": [
         {
+          "command": "zenn-preview.new-chapter",
+          "when": "viewItem == book",
+          "group": "inline@1"
+        },
+        {
           "command": "zenn-preview.preview-zenn",
           "when": "view == zenn-articles-tree-view && viewItem == article || view == zenn-books-tree-view && viewItem == book || viewItem == bookChapter",
-          "group": "inline"
+          "group": "inline@2"
         }
       ]
     },

--- a/package.json
+++ b/package.json
@@ -91,6 +91,11 @@
         "command": "zenn-preview.refresh-books",
         "title": "本一覧を更新",
         "icon": "$(refresh)"
+      },
+      {
+        "command": "zenn-preview.new-chapter",
+        "title": "チャプターを新規作成",
+        "icon": "$(new-file)"
       }
     ],
     "menus": {

--- a/src/commands/newBook.ts
+++ b/src/commands/newBook.ts
@@ -1,5 +1,7 @@
 import * as vscode from "vscode";
 
+import { createBookChapterFile } from "./newChapter";
+
 import { AppContext } from "../context/app";
 import { generateSlug } from "../utils/helpers";
 import { BOOK_SLUG_PATTERN } from "../utils/patterns";
@@ -36,23 +38,13 @@ const createBookConfigFile = async (bookUri: vscode.Uri) => {
 };
 
 /**
- * 本のチャプターのテンプレート文字列を生成する
- */
-const generateBookChapterTemplate = () =>
-  ["---", 'title: ""', "---"].join("\n") + "\n";
-
-/**
- * 本のチャプターファイルを作成する
+ * 本の作成に基づいてチャプターファイルを作成する
  */
 const createBookChapterFiles = async (bookUri: vscode.Uri) => {
   await Promise.all(
-    TEMPLATE_CHAPTERS.map(async (filename) => {
-      const templateText = generateBookChapterTemplate();
-      const chapterText = new TextEncoder().encode(templateText);
-      const chapterUri = vscode.Uri.joinPath(bookUri, `${filename}.md`);
-
-      await vscode.workspace.fs.writeFile(chapterUri, chapterText);
-    })
+    TEMPLATE_CHAPTERS.map((fileName) =>
+      createBookChapterFile(fileName, bookUri)
+    )
   );
 };
 

--- a/src/commands/newChapter.ts
+++ b/src/commands/newChapter.ts
@@ -1,0 +1,101 @@
+import * as vscode from "vscode";
+
+import { AppContext } from "../context/app";
+import { generateSlug } from "../utils/helpers";
+import { BOOK_CHAPTER_SLUG_PATTERN } from "../utils/patterns";
+import { isExistsUri } from "../utils/vscodeHelpers";
+
+/**
+ * 本のチャプターのテンプレート文字列を生成する
+ */
+export const generateBookChapterTemplate = () =>
+  ["---", 'title: ""', "---"].join("\n") + "\n";
+
+/**
+ * 本のチャプターファイルを作成する
+ */
+export const createBookChapterFile = async (
+  filename: string,
+  bookUri: vscode.Uri
+): Promise<void> => {
+  const templateText = generateBookChapterTemplate();
+  const chapterText = new TextEncoder().encode(templateText);
+  const chapterUri = vscode.Uri.joinPath(bookUri, `${filename}.md`);
+
+  await vscode.workspace.fs.writeFile(chapterUri, chapterText);
+};
+
+/**
+ * チャプターの新規作成コマンドの実装
+ */
+export const newChapterCommand = (context?: AppContext) => {
+  const generator = async (): Promise<boolean> => {
+    if (!context) throw new Error("コマンドを実行できません");
+
+    // 本のフォルダ名を取得
+    const bookList = await vscode.workspace.fs
+      .readDirectory(context.booksFolderUri)
+      .then((result) =>
+        result
+          .filter((file) => {
+            return file[1] === vscode.FileType.Directory;
+          })
+          .map(([file]) => file)
+      );
+
+    // チャプターを作成する本を選択
+    const selectedBookFolder = await vscode.window.showQuickPick(bookList, {
+      placeHolder: "チャプターを作成する本を選択",
+      canPickMany: false,
+    });
+
+    if (!selectedBookFolder) return false;
+
+    // チャプタースラグの作成
+    const chapterSlug = await vscode.window.showInputBox({
+      value: generateSlug(),
+      prompt: "チャプターのslugを入力",
+      title: "チャプターの新規作成",
+      valueSelection: [0, 14],
+      validateInput: async (slug) => {
+        if (!BOOK_CHAPTER_SLUG_PATTERN.test(slug)) return "不正なslugです";
+
+        const uri = vscode.Uri.joinPath(
+          context.booksFolderUri,
+          selectedBookFolder,
+          `${slug}.md`
+        );
+        const isExists = await isExistsUri(uri);
+
+        if (isExists) return "既に存在しているslugです";
+
+        return null;
+      },
+    });
+
+    // チャプタースラグが不正やすでに存在している場合は失敗
+    if (!chapterSlug) return false;
+
+    const bookUri = vscode.Uri.joinPath(
+      context.booksFolderUri,
+      selectedBookFolder
+    );
+
+    // ファイルを作成する
+    await createBookChapterFile(chapterSlug, bookUri);
+
+    return true;
+  };
+
+  return () => {
+    generator()
+      .then((isCreated) => {
+        if (isCreated) {
+          vscode.window.showInformationMessage("チャプターを作成しました");
+        }
+      })
+      .catch(() => {
+        vscode.window.showErrorMessage("チャプターの作成に失敗しました");
+      });
+  };
+};

--- a/src/context/commands.ts
+++ b/src/context/commands.ts
@@ -4,6 +4,7 @@ import { AppContext } from "./app";
 
 import { newArticleCommand } from "../commands/newArticle";
 import { newBookCommand } from "../commands/newBook";
+import { newChapterCommand } from "../commands/newChapter";
 import { previewCommand } from "../commands/preview";
 import { refreshArticlesCommand } from "../commands/refreshArticles";
 import { refreshBooksCommand } from "../commands/refreshBooks";
@@ -44,6 +45,12 @@ export const initializeCommands = (
     vscode.commands.registerCommand(
       APP_COMMAND.REFRESH_BOOKS,
       refreshBooksCommand(context)
+    ),
+
+    // チャプターファイルの作成コマンド
+    vscode.commands.registerCommand(
+      APP_COMMAND.NEW_CHAPTER,
+      newChapterCommand(context)
     ),
   ];
 };

--- a/src/variables.ts
+++ b/src/variables.ts
@@ -19,6 +19,9 @@ export const APP_COMMAND = {
 
   /** 本一覧の再取得 */
   REFRESH_BOOKS: pkg.contributes.commands[4].command,
+
+  /** チャプターの新規作成 */
+  NEW_CHAPTER: pkg.contributes.commands[5].command,
 } as const;
 
 /**


### PR DESCRIPTION
## :bookmark_tabs: Summary

「チャプターの新規作成」を行うコマンドを実装しました。コマンドパレットから実行した場合にはチャプターを作成する対象となる本の候補がサジェストされ、対象の本を選択してからチャプタースラグを入力することでチャプターファイルが作成されます。TreeView の BOOKS からは記事の新規作成と同じアイコンでチャプターを作成できるようにしました。

Resolves #52 

### :clipboard: Tasks

プルリクエストを作成いただく際、お手数ですが以下の内容についてご確認をお願いします。

- [x] :book: [Contribution Guide](https://github.com/zenn-dev/zenn-vscode-extension/blob/main/CONTRIBUTING.md) を読んだ
- [x] :woman_technologist: `canary` ブランチに対するプルリクエストである
- [x] 実行して正しく動作しているか確認する
- [x] 不要なコードが含まれていないか( コメントやログの消し忘れに注意 )
- [x] XSS になるようなコードが含まれていないか
- [x] Pull Reuqest の内容は妥当か( 膨らみすぎてないか )

より詳しい内容は [Pull Request Policy](https://github.com/zenn-dev/zenn-vscode-extension/blob/main/docs/pull_request_policy.md) を参照してください。
