### PR TITLE
fix: WebView内のリンクが正しく動作しないバグを修正

### DIFF
--- a/src/context/app.ts
+++ b/src/context/app.ts
@@ -7,6 +7,7 @@ import {
   BOOK_CONFIG_FILE_PATTERN,
   BOOK_COVER_IMAGE_FILE_PATTERN,
 } from "../utils/patterns";
+import { toFullPath } from "../utils/vscodeHelpers";
 
 type EventCallback = (event: ContentsEvent) => void;
 
@@ -58,7 +59,7 @@ export const createAppContext = (
      * @note slug が不正でも ContentsType を取得したい場合があるため、slug は考慮されていません
      */
     getContentsType: (uri: vscode.Uri): ContentsType | undefined => {
-      const path = uri.toString();
+      const path = toFullPath(uri); // schemeを含む完全なパス文字列を使用する
 
       if (uriPatterns.article.test(path)) return "article";
       if (uriPatterns.book.test(path)) return "book";

--- a/src/context/webview.ts
+++ b/src/context/webview.ts
@@ -43,7 +43,7 @@ export const initializeWebview = (context: AppContext): vscode.Disposable[] => {
 
         if (!content) return;
 
-        const uri = toVSCodeUri(content.path);
+        const uri = toVSCodeUri(content.fullPath);
         const previewPanel = createPreviewPanel(uri, panel, content);
 
         registerPreviewPanel(context, previewPanel);

--- a/src/schemas/article.ts
+++ b/src/schemas/article.ts
@@ -11,7 +11,7 @@ import { EMOJI_REGEX, FRONT_MATTER_PATTERN } from "../utils/patterns";
 import {
   getFilenameFromUrl,
   openTextDocument,
-  toPath,
+  toFullPath,
 } from "../utils/vscodeHelpers";
 
 /**
@@ -143,7 +143,7 @@ export const loadArticlePreviewContent = async (
   return {
     type: "article",
     article: article.value,
-    path: toPath(uri),
+    fullPath: toFullPath(uri),
     filename: article.filename,
     html: markdownToHtml(article.markdown, panel),
     panelTitle: `${

--- a/src/schemas/book.ts
+++ b/src/schemas/book.ts
@@ -9,7 +9,7 @@ import { withCache } from "./utils";
 import { AppContext } from "../context/app";
 import { ContentBase, ContentsLoadResult, PreviewContentBase } from "../types";
 import { FileResult } from "../types";
-import { toPath, getFilenameFromUrl } from "../utils/vscodeHelpers";
+import { getFilenameFromUrl, toFullPath } from "../utils/vscodeHelpers";
 
 /**
  * 本の基本情報
@@ -57,10 +57,10 @@ export type BookLoadResult = ContentsLoadResult<BookContent>;
  * プレビューで使う本のチャプターのメタデータ
  */
 export interface PreviewChapterMeta {
-  path: string;
   slug: string;
-  title: string | undefined | null;
+  fullPath: string;
   isExcluded: boolean;
+  title: string | undefined | null; // 省略できないようにオプショナルにはしない
 }
 
 /**
@@ -201,8 +201,8 @@ export const loadBookPreviewContent = async (
   return {
     type: "book",
     book: book.value,
-    path: toPath(book.uri),
     filename: book.filename,
+    fullPath: toFullPath(book.uri),
     panelTitle: `${book.value.title || book.filename || "本"} のプレビュー`,
 
     // カバー画像のURLをWebView内で表示できる形に変更する
@@ -215,7 +215,7 @@ export const loadBookPreviewContent = async (
       book.chapters.map((meta) =>
         loadBookChapterContent(context, meta.uri).then((chapter) => ({
           slug: meta.slug,
-          path: toPath(meta.uri),
+          fullPath: toFullPath(meta.uri),
           title: !ContentError.isError(chapter) ? chapter.value.title : null,
           isExcluded: meta.isExcluded,
         }))

--- a/src/schemas/bookChapter.ts
+++ b/src/schemas/bookChapter.ts
@@ -12,7 +12,7 @@ import { FRONT_MATTER_PATTERN } from "../utils/patterns";
 import {
   openTextDocument,
   getFilenameFromUrl,
-  toPath,
+  toFullPath,
 } from "../utils/vscodeHelpers";
 
 /**
@@ -46,7 +46,7 @@ export interface BookChapterPreviewContent extends PreviewContentBase {
   type: "bookChapter";
   html: string;
   book: Book;
-  bookPath: string;
+  bookFullPath: string;
   bookFilename: string;
   chapter: BookChapter;
 }
@@ -113,9 +113,9 @@ export const loadBookChapterPreviewContent = async (
     type: "bookChapter",
     book: book.value,
     chapter: chapter.value,
-    path: toPath(chapter.uri),
+    fullPath: toFullPath(chapter.uri),
     filename: chapter.filename,
-    bookPath: toPath(book.uri),
+    bookFullPath: toFullPath(book.uri),
     bookFilename: book.filename,
     html: markdownToHtml(chapter.markdown, panel),
     panelTitle: `${

--- a/src/schemas/previewPanel.ts
+++ b/src/schemas/previewPanel.ts
@@ -9,11 +9,7 @@ import { PreviewPanelCacheKey } from "../contentsCache";
 import { AppContext } from "../context/app";
 import { ContentsType, PreviewContents, PreviewEvent } from "../types";
 import { createWebviewHtml, getWebviewSrc } from "../utils/panel";
-import {
-  toPath,
-  toVSCodeUri,
-  createWebViewPanel,
-} from "../utils/vscodeHelpers";
+import { toVSCodeUri, createWebViewPanel } from "../utils/vscodeHelpers";
 
 export interface PreviewPanel {
   uri: vscode.Uri;
@@ -54,7 +50,7 @@ export const createPreviewPanel = (
     uri,
     panel,
     defaultContent,
-    cacheKey: `previewPanel:${toPath(uri)}`,
+    cacheKey: `previewPanel:${uri.path}`,
   };
 };
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -83,7 +83,7 @@ export type ContentsEvent =
  * プレビューするための基本データ型
  */
 export interface PreviewContentBase {
-  path: string;
+  fullPath: string;
   filename: string;
   panelTitle: string;
   type: ContentsType;

--- a/src/utils/vscodeHelpers.ts
+++ b/src/utils/vscodeHelpers.ts
@@ -4,9 +4,32 @@ import { APP_ID } from "../variables";
 
 /**
  * Uri を文字列に変換する
+ * @note
+ * scheme(`file`,`http`)を含まないことに注意！
+ * この関数の返り値は WebView 内のリンクとして使用できません ( ブラウザ上でのみエラーが発生します　)
+ *
+ * @example
+ * const fullPath = toPath(articlePath); // /user/articles/any-article.md
  */
 export const toPath = (uri: string | vscode.Uri): string => {
   return typeof uri === "string" ? vscode.Uri.parse(uri).path : uri.path;
+};
+
+/**
+ * Uri 全体を文字列に変換する
+ * @note
+ * scheme(`file`,`http`)を含みますので、ブラウザとローカルで出力結果が変わることに注意！
+ * この関数の返り値は WebView 内のリンクとして使用できます。
+ *
+ * @example
+ * // ローカルで実行した場合
+ * const fullPath = toFullPath(articlePath); // file:///user/articles/any-article.md
+ *
+ * // ブラウザ(github.devなど)で実行した場合
+ * const fullPath = toFullPath(articlePath); // https:///user/articles/any-article.md
+ */
+export const toFullPath = (uri: vscode.Uri): string => {
+  return uri.toString();
 };
 
 /**

--- a/src/webviews/src/components/BookChapterPreview/index.tsx
+++ b/src/webviews/src/components/BookChapterPreview/index.tsx
@@ -32,7 +32,7 @@ interface BookChapterPreviewProps {
 }
 
 export const BookChapterPreview = ({ content }: BookChapterPreviewProps) => {
-  const { html, filename, book, chapter, bookPath, bookFilename } = content;
+  const { html, filename, book, chapter, bookFullPath, bookFilename } = content;
 
   const vscode = useVSCodeApi();
   const validationErrors = useMemo(
@@ -43,7 +43,7 @@ export const BookChapterPreview = ({ content }: BookChapterPreviewProps) => {
   const goToBookPreviewPage = () => {
     const event: PreviewEvent = {
       type: "open-preview-panel",
-      payload: { path: bookPath },
+      payload: { path: bookFullPath },
     };
 
     vscode.postMessage(event);

--- a/src/webviews/src/components/BookPreview/index.tsx
+++ b/src/webviews/src/components/BookPreview/index.tsx
@@ -116,7 +116,7 @@ export const BookPreview = ({ content }: BookPreviewProps) => {
             <li key={chapter.slug}>
               <div
                 className={styles.chapterLink}
-                onClick={() => previewChapterPage(chapter.path)}
+                onClick={() => previewChapterPage(chapter.fullPath)}
               >
                 {chapter.title || "タイトルが設定されていません"}
                 <span className={styles.chapterFilename}>
@@ -135,7 +135,7 @@ export const BookPreview = ({ content }: BookPreviewProps) => {
               <li key={chapter.slug}>
                 <div
                   className={styles.chapterLink}
-                  onClick={() => previewChapterPage(chapter.path)}
+                  onClick={() => previewChapterPage(chapter.fullPath)}
                 >
                   {chapter.title || "タイトルが設定されていません"}
                   <span className={styles.chapterFilename}>


### PR DESCRIPTION
## :bookmark_tabs: Summary

- このバグはブラウザ上でのみ発生します。ローカルのVSCodeでは発生しません。
- `vscode.Uri.path` で取得した文字列をリンクに使用していたことがバグの原因でした
- そのため `vscode.Uri.toString()` を使用するように修正しました


## 関連

#70 

## :clipboard: Tasks

プルリクエストを作成いただく際、お手数ですが以下の内容についてご確認をお願いします。

- [x] :book: [Contribution Guide](https://github.com/zenn-dev/zenn-vscode-extension/blob/main/CONTRIBUTING.md) を読んだ
- [x] :woman_technologist: `canary` ブランチに対するプルリクエストである
- [x] 実行して正しく動作しているか確認する
- [x] 不要なコードが含まれていないか( コメントやログの消し忘れに注意 )
- [x] XSS になるようなコードが含まれていないか
- [x] Pull Reuqest の内容は妥当か( 膨らみすぎてないか )

より詳しい内容は [Pull Request Policy](https://github.com/zenn-dev/zenn-vscode-extension/blob/main/docs/pull_request_policy.md) を参照してください。
