### PR TITLE
fix: 同一画像のリンクが複数個ある場合に１つ目しかレンダリングされないバグを修正

### DIFF
--- a/examples/articles/local-image-test.md
+++ b/examples/articles/local-image-test.md
@@ -39,3 +39,14 @@ published: true
 `![](http://placehold.jp/54/e3f2ff/000000/720x480.png?text=zenn-editor.png)`
 
 ![](http://placehold.jp/54/e3f2ff/000000/720x480.png?text=zenn-editor.png)
+
+## 同一画像の連続表示
+
+```md
+![1st](/images/example-images/zenn-editor.png)
+![2nd](/images/example-images/zenn-editor.png)
+```
+
+![1st](/images/example-images/zenn-editor.png)
+
+![2nd](/images/example-images/zenn-editor.png)

--- a/src/utils/markdownHelpers.ts
+++ b/src/utils/markdownHelpers.ts
@@ -1,8 +1,6 @@
 import * as vscode from "vscode";
 import ZennMarkdownToHtml from "zenn-markdown-html";
 
-import { createWebViewPanel } from "./vscodeHelpers";
-
 type Transformer = (markdown: string) => string;
 
 /**

--- a/src/utils/markdownHelpers.ts
+++ b/src/utils/markdownHelpers.ts
@@ -24,7 +24,7 @@ export const transformLocalImage =
       const url = panel.webview.asWebviewUri(imageUri);
 
       return htmlText.replace(
-        new RegExp(`(<img\\s[^>]*src=")/images/[^"]+("[^>]*>)`),
+        new RegExp(`(<img\\s[^>]*src=")/images/[^"]+("[^>]*>)`, "g"),
         `$1${url}$2`
       );
     }, html);


### PR DESCRIPTION
## :bookmark_tabs: Summary

- img タグの src を変換する過程で同一画像の複数リンクに対して一回しか文字列置換が行われないことによって起こされる、同一画像の複数個のリンクがある場合に１つ目の画像しか正しく表示されないというバグを修正しました。

Resolves #72 

### :clipboard: Tasks

プルリクエストを作成いただく際、お手数ですが以下の内容についてご確認をお願いします。

- [x] :book: [Contribution Guide](https://github.com/zenn-dev/zenn-vscode-extension/blob/main/CONTRIBUTING.md) を読んだ
- [x] :woman_technologist: `canary` ブランチに対するプルリクエストである
- [x] 実行して正しく動作しているか確認する
- [x] 不要なコードが含まれていないか( コメントやログの消し忘れに注意 )
- [x] XSS になるようなコードが含まれていないか
- [x] Pull Reuqest の内容は妥当か( 膨らみすぎてないか )

より詳しい内容は [Pull Request Policy](https://github.com/zenn-dev/zenn-vscode-extension/blob/main/docs/pull_request_policy.md) を参照してください。
