### PR TITLE
improve: アクティブファイルがプレビュー可能な時のみプレビューボタンが表示されるように改善

### DIFF
--- a/package.json
+++ b/package.json
@@ -157,7 +157,7 @@
       "editor/title": [
         {
           "command": "zenn-preview.preview-zenn",
-          "when": "resourceLangId == markdown",
+          "when": "resourceLangId == markdown && zenn-preview.active-document-can-preview",
           "group": "navigation"
         }
       ]

--- a/src/context/editor/index.ts
+++ b/src/context/editor/index.ts
@@ -6,6 +6,7 @@ import { initializeBookChapterEditor } from "./bookChapter";
 import { initializeBookConfigEditor } from "./bookConfig";
 import { initializeBookCoverImageEditor } from "./bookCoverImage";
 
+import { checkUriCanPreview } from "../../schemas/previewPanel";
 import { AppContext } from "../app";
 
 /**
@@ -44,7 +45,17 @@ export const initializeEditor = (context: AppContext): vscode.Disposable[] => {
     vscode.window.onDidChangeActiveTextEditor((event) => {
       if (!event || !event.viewColumn) return;
 
-      const key = cache.createKey("previewPanel", event.document.uri);
+      const activeDocumentUri = event.document.uri;
+
+      // 現在のドキュメントのUriがプレビュー可能なものならエディタタイトル上にプレビューボタンを表示
+      const canPreview = checkUriCanPreview(context, activeDocumentUri);
+      vscode.commands.executeCommand(
+        "setContext",
+        "zenn-preview.active-document-can-preview",
+        canPreview
+      );
+
+      const key = cache.createKey("previewPanel", activeDocumentUri);
       const panel = cache.getCache(key)?.panel;
 
       if (!panel) return;

--- a/src/schemas/previewPanel.ts
+++ b/src/schemas/previewPanel.ts
@@ -61,7 +61,10 @@ export const createPreviewPanel = (
 /**
  * プレビュー可能な Uri か判別する
  */
-const checkUriCanPreview = (context: AppContext, uri: vscode.Uri): boolean => {
+export const checkUriCanPreview = (
+  context: AppContext,
+  uri: vscode.Uri
+): boolean => {
   const type = context.getContentsType(uri);
   const canPreviewContentsType: ContentsType[] = [
     "article",


### PR DESCRIPTION
## :bookmark_tabs: Summary

- 現在開いているファイルのUriからプレビュー可能のコンテンツであるかどうかを判定した上で、プレビューボタンがエディタタイトルに表示されるように改善しました。

Resolves #74 

### :clipboard: Tasks

プルリクエストを作成いただく際、お手数ですが以下の内容についてご確認をお願いします。

- [x] :book: [Contribution Guide](https://github.com/zenn-dev/zenn-vscode-extension/blob/main/CONTRIBUTING.md) を読んだ
- [x] :woman_technologist: `canary` ブランチに対するプルリクエストである
- [x] 実行して正しく動作しているか確認する
- [x] 不要なコードが含まれていないか( コメントやログの消し忘れに注意 )
- [x] XSS になるようなコードが含まれていないか
- [x] Pull Reuqest の内容は妥当か( 膨らみすぎてないか )

より詳しい内容は [Pull Request Policy](https://github.com/zenn-dev/zenn-vscode-extension/blob/main/docs/pull_request_policy.md) を参照してください。
