### PR TITLE
feat: テンプレート作成後に編集作業をすぐに始められるように作成したファイルを開く機能を追加

### DIFF
--- a/src/commands/newArticle.ts
+++ b/src/commands/newArticle.ts
@@ -65,16 +65,11 @@ export const newArticleCommand = (context?: AppContext) => {
       .then((fileUri) => {
         if (fileUri) {
           vscode.window.showInformationMessage("記事を作成しました");
-          return fileUri;
+          vscode.window.showTextDocument(fileUri);
         }
       })
       .catch(() => {
         vscode.window.showErrorMessage("記事の作成に失敗しました");
-      })
-      .then((fileUri) => {
-        if (fileUri) {
-          vscode.window.showTextDocument(fileUri);
-        }
       });
   };
 };

--- a/src/commands/newArticle.ts
+++ b/src/commands/newArticle.ts
@@ -23,7 +23,7 @@ const generateArticleTemplate = () =>
  * 記事の新規作成コマンドの実装
  */
 export const newArticleCommand = (context?: AppContext) => {
-  const generator = async (): Promise<boolean> => {
+  const generator = async (): Promise<vscode.Uri | null> => {
     if (!context) throw new Error("コマンドを実行できません");
 
     const aritcleSlug = await vscode.window.showInputBox({
@@ -46,7 +46,7 @@ export const newArticleCommand = (context?: AppContext) => {
       },
     });
 
-    if (!aritcleSlug) return false;
+    if (!aritcleSlug) return null;
 
     const { articlesFolderUri } = context;
     const text = new TextEncoder().encode(generateArticleTemplate());
@@ -57,18 +57,24 @@ export const newArticleCommand = (context?: AppContext) => {
 
     await vscode.workspace.fs.writeFile(fileUri, text);
 
-    return true;
+    return fileUri;
   };
 
   return () => {
     generator()
-      .then((isCreated) => {
-        if (isCreated) {
+      .then((fileUri) => {
+        if (fileUri) {
           vscode.window.showInformationMessage("記事を作成しました");
+          return fileUri;
         }
       })
       .catch(() => {
         vscode.window.showErrorMessage("記事の作成に失敗しました");
+      })
+      .then((fileUri) => {
+        if (fileUri) {
+          vscode.window.showTextDocument(fileUri);
+        }
       });
   };
 };

--- a/src/commands/newBook.ts
+++ b/src/commands/newBook.ts
@@ -30,29 +30,36 @@ const generateBookConfigTemplate = () =>
 /**
  * 本の設定ファイルを生成する
  */
-const createBookConfigFile = async (bookUri: vscode.Uri) => {
+const createBookConfigFile = async (
+  bookUri: vscode.Uri
+): Promise<vscode.Uri> => {
   const configText = new TextEncoder().encode(generateBookConfigTemplate());
   const configUri = vscode.Uri.joinPath(bookUri, "config.yaml");
 
   await vscode.workspace.fs.writeFile(configUri, configText);
+
+  return configUri;
 };
 
 /**
  * 本の作成に基づいてチャプターファイルを作成する
  */
-const createBookChapterFiles = async (bookUri: vscode.Uri) => {
-  await Promise.all(
+const createBookChapterFiles = async (
+  bookUri: vscode.Uri
+): Promise<vscode.Uri[]> => {
+  const bookChapterFileUris = await Promise.all(
     TEMPLATE_CHAPTERS.map((fileName) =>
       createBookChapterFile(fileName, bookUri)
     )
   );
+  return bookChapterFileUris;
 };
 
 /**
  * 本の新規作成コマンドの実装
  */
 export const newBookCommand = (context?: AppContext) => {
-  const generator = async (): Promise<boolean> => {
+  const generator = async (): Promise<vscode.Uri | null> => {
     if (!context) throw new Error("コマンドを実行できません");
 
     const bookSlug = await vscode.window.showInputBox({
@@ -72,28 +79,34 @@ export const newBookCommand = (context?: AppContext) => {
       },
     });
 
-    if (!bookSlug) return false;
+    if (!bookSlug) return null;
 
     const bookUri = vscode.Uri.joinPath(context.booksFolderUri, bookSlug);
 
     await vscode.workspace.fs.createDirectory(bookUri);
-    await Promise.all([
+    const [configFileUri] = await Promise.all([
       createBookConfigFile(bookUri),
       createBookChapterFiles(bookUri),
     ]);
 
-    return true;
+    return configFileUri;
   };
 
   return () => {
     generator()
-      .then((isCreated) => {
-        if (isCreated) {
+      .then((configFileUri) => {
+        if (configFileUri) {
           vscode.window.showInformationMessage("本を作成しました");
+          return configFileUri;
         }
       })
       .catch(() => {
         vscode.window.showErrorMessage("本の作成に失敗しました");
+      })
+      .then((configFileUri) => {
+        if (configFileUri) {
+          vscode.window.showTextDocument(configFileUri);
+        }
       });
   };
 };

--- a/src/commands/newBook.ts
+++ b/src/commands/newBook.ts
@@ -97,16 +97,11 @@ export const newBookCommand = (context?: AppContext) => {
       .then((configFileUri) => {
         if (configFileUri) {
           vscode.window.showInformationMessage("本を作成しました");
-          return configFileUri;
+          vscode.window.showTextDocument(configFileUri);
         }
       })
       .catch(() => {
         vscode.window.showErrorMessage("本の作成に失敗しました");
-      })
-      .then((configFileUri) => {
-        if (configFileUri) {
-          vscode.window.showTextDocument(configFileUri);
-        }
       });
   };
 };

--- a/src/commands/newChapter.ts
+++ b/src/commands/newChapter.ts
@@ -95,16 +95,11 @@ export const newChapterCommand = (context?: AppContext) => {
       .then((fileUri) => {
         if (fileUri) {
           vscode.window.showInformationMessage("チャプターを作成しました");
-          return fileUri;
+          vscode.window.showTextDocument(fileUri);
         }
       })
       .catch(() => {
         vscode.window.showErrorMessage("チャプターの作成に失敗しました");
-      })
-      .then((fileUri) => {
-        if (fileUri) {
-          vscode.window.showTextDocument(fileUri);
-        }
       });
   };
 };


### PR DESCRIPTION
## :bookmark_tabs: Summary

- `Zenn: New Article` および `Zenn: New Book Chapter` コマンドを実行した際にそれぞれ作成したファイルを開く機能を追加しました
- `Zenn: New Book` コマンドによる本テンプレート作成時には `config.yaml` 設定ファイルを開く機能を追加しました。

Resolves #76 

### :clipboard: Tasks

プルリクエストを作成いただく際、お手数ですが以下の内容についてご確認をお願いします。

- [x] :book: [Contribution Guide](https://github.com/zenn-dev/zenn-vscode-extension/blob/main/CONTRIBUTING.md) を読んだ
- [x] :woman_technologist: `canary` ブランチに対するプルリクエストである
- [x] 実行して正しく動作しているか確認する
- [x] 不要なコードが含まれていないか( コメントやログの消し忘れに注意 )
- [x] XSS になるようなコードが含まれていないか
- [x] Pull Reuqest の内容は妥当か( 膨らみすぎてないか )

より詳しい内容は [Pull Request Policy](https://github.com/zenn-dev/zenn-vscode-extension/blob/main/docs/pull_request_policy.md) を参照してください。
