### PR TITLE
fix: articlesやbooksフォルダが無い場合のエラーメッセージが表示されないよう修正

### DIFF
--- a/src/treeview/article/articlesTreeViewProvider.ts
+++ b/src/treeview/article/articlesTreeViewProvider.ts
@@ -33,17 +33,22 @@ export class ArticlesTreeViewProvider implements TreeDataProvider {
   async getChildren(element?: PreviewTreeItem): Promise<ChildTreeItem[]> {
     if (element) return element.getChildren();
 
-    const articleContents = await loadArticleContents(
-      this.context,
-      this.forceRefresh
-    );
+    try {
+      const articleContents = await loadArticleContents(
+        this.context,
+        this.forceRefresh
+      );
 
-    const treeItems = articleContents.map((result) =>
-      ContentError.isError(result)
-        ? new PreviewTreeErrorItem(this.context, result)
-        : new ArticleTreeItem(this.context, result)
-    );
+      const treeItems = articleContents.map((result) =>
+        ContentError.isError(result)
+          ? new PreviewTreeErrorItem(this.context, result)
+          : new ArticleTreeItem(this.context, result)
+      );
 
-    return PreviewTreeItem.sortTreeItems(treeItems);
+      return PreviewTreeItem.sortTreeItems(treeItems);
+    } catch {
+      console.error("articlesフォルダ内にコンテンツが見つかりませんでした");
+      return [];
+    }
   }
 }

--- a/src/treeview/book/booksTreeViewProvider.ts
+++ b/src/treeview/book/booksTreeViewProvider.ts
@@ -33,17 +33,22 @@ export class BooksTreeViewProvider implements TreeDataProvider {
   async getChildren(element?: PreviewTreeItem): Promise<ChildTreeItem[]> {
     if (element) return element.getChildren();
 
-    const bookContents = await loadBookContents(
-      this.context,
-      this.forceRefresh
-    );
+    try {
+      const bookContents = await loadBookContents(
+        this.context,
+        this.forceRefresh
+      );
 
-    const treeItems = bookContents.map((result) =>
-      ContentError.isError(result)
-        ? new PreviewTreeErrorItem(this.context, result)
-        : new BookTreeItem(this.context, result)
-    );
+      const treeItems = bookContents.map((result) =>
+        ContentError.isError(result)
+          ? new PreviewTreeErrorItem(this.context, result)
+          : new BookTreeItem(this.context, result)
+      );
 
-    return PreviewTreeItem.sortTreeItems(treeItems);
+      return PreviewTreeItem.sortTreeItems(treeItems);
+    } catch {
+      console.error("booksフォルダ内にコンテンツが見つかりませんでした");
+      return [];
+    }
   }
 }


### PR DESCRIPTION
## :bookmark_tabs: Summary

- コンテンツのロード時に発生しうるエラーを補足し、`console.error` でコンソール通知するように修正しました。

エラーの扱い的には方針に沿っているか不安なのでそちらについてコメントいただけるとありがたいです。

Resolves #78 

### :clipboard: Tasks

プルリクエストを作成いただく際、お手数ですが以下の内容についてご確認をお願いします。

- [x] :book: [Contribution Guide](https://github.com/zenn-dev/zenn-vscode-extension/blob/main/CONTRIBUTING.md) を読んだ
- [x] :woman_technologist: `canary` ブランチに対するプルリクエストである
- [x] 実行して正しく動作しているか確認する
- [x] 不要なコードが含まれていないか( コメントやログの消し忘れに注意 )
- [x] XSS になるようなコードが含まれていないか
- [x] Pull Reuqest の内容は妥当か( 膨らみすぎてないか )

より詳しい内容は [Pull Request Policy](https://github.com/zenn-dev/zenn-vscode-extension/blob/main/docs/pull_request_policy.md) を参照してください。
