### PR TITLE
fix: 埋め込み要素のレンダリングバグを修正

### DIFF
--- a/src/utils/markdownHelpers.ts
+++ b/src/utils/markdownHelpers.ts
@@ -40,7 +40,9 @@ export const markdownToHtml = (
 ): string => {
   return [transformLocalImage(panel)].reduce(
     (text, transformer) => transformer(text),
-    ZennMarkdownToHtml(markdown)
+    ZennMarkdownToHtml(markdown, {
+      embedOrigin: "https://embed.zenn.studio",
+    })
   );
 };
 


### PR DESCRIPTION
## :bookmark_tabs: Summary

- zenn-markdown-html パッケージの更新にともない発生していた埋め込み要素がレンダリングされないバグ(embedOrigin オプションによるもの)を修正しました。

関連: https://github.com/zenn-dev/zenn-editor/pull/420

## :clipboard: Tasks

プルリクエストを作成いただく際、お手数ですが以下の内容についてご確認をお願いします。

- [x] :book: [Contribution Guide](https://github.com/zenn-dev/zenn-vscode-extension/blob/main/CONTRIBUTING.md) を読んだ
- [x] :woman_technologist: `canary` ブランチに対するプルリクエストである
- [x] 実行して正しく動作しているか確認する
- [x] 不要なコードが含まれていないか( コメントやログの消し忘れに注意 )
- [x] XSS になるようなコードが含まれていないか
- [x] Pull Reuqest の内容は妥当か( 膨らみすぎてないか )

より詳しい内容は [Pull Request Policy](https://github.com/zenn-dev/zenn-vscode-extension/blob/main/docs/pull_request_policy.md) を参照してください。
