### PR TITLE
fix: publish が上手くいかない問題を修正

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,15 +15,15 @@ jobs:
         with:
           node-version: 16
 
-      - uses: pnpm/action-setup@v2
-        with:
-          version: 7
-
+      # vsce が pnpm に対応してないので npm でインストールする。
+      # lock ファイルを参照せずにインストールするので不安要素はあるが、
+      # バージョンがそこまで違っていなければ問題ないと判断
       - name: node_modules をインストール
-        run: pnpm install
+        run: npm install --no-package-lock
 
+      # vsce が pnpm に対応してないので npm で実行する
       - name: VSCode拡張をリリース
-        run: pnpm publish:vsce
+        run: npm run publish:vsce
         env:
           VSCE_PAT: ${{ secrets.VSCE_PAT }}
 

--- a/.vscodeignore
+++ b/.vscodeignore
@@ -1,6 +1,7 @@
 .github/**
 .vscode/**
 .vscode-test-web/**
+.idea/**
 docs/**
 out/**
 src/**

--- a/.yarnrc
+++ b/.yarnrc
@@ -1,1 +1,0 @@
---ignore-engines true


### PR DESCRIPTION
## :bookmark_tabs: Summary

GitHub Actions で `vsce publish` コマンドが失敗する問題を修正しました。

## :clipboard: Tasks

プルリクエストを作成いただく際、お手数ですが以下の内容についてご確認をお願いします。

- [x] :book: [Contribution Guide](https://github.com/zenn-dev/zenn-vscode-extension/blob/main/CONTRIBUTING.md) を読んだ
- [x] :woman_technologist: `canary` ブランチに対するプルリクエストである
- [x] 実行して正しく動作しているか確認する
- [x] 不要なコードが含まれていないか( コメントやログの消し忘れに注意 )
- [x] XSS になるようなコードが含まれていないか
- [x] Pull Reuqest の内容は妥当か( 膨らみすぎてないか )

より詳しい内容は [Pull Request Policy](https://github.com/zenn-dev/zenn-vscode-extension/blob/main/docs/pull_request_policy.md) を参照してください。
