### PR TITLE
feat: エディター -> プレビューへの片方向スクロール同期

### DIFF
--- a/package.json
+++ b/package.json
@@ -252,9 +252,9 @@
     "js-yaml": "^4.1.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "zenn-content-css": "^0.1.139",
-    "zenn-embed-elements": "^0.1.139",
-    "zenn-markdown-html": "^0.1.139",
-    "zenn-model": "^0.1.139"
+    "zenn-content-css": "^0.1.155",
+    "zenn-embed-elements": "^0.1.155",
+    "zenn-markdown-html": "^0.1.155",
+    "zenn-model": "^0.1.155"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -37,20 +37,20 @@ specifiers:
   vsce: ^2.13.0
   webpack: ^5.73.0
   webpack-cli: ^4.10.0
-  zenn-content-css: ^0.1.139
-  zenn-embed-elements: ^0.1.139
-  zenn-markdown-html: ^0.1.139
-  zenn-model: ^0.1.139
+  zenn-content-css: ^0.1.155
+  zenn-embed-elements: ^0.1.155
+  zenn-markdown-html: ^0.1.155
+  zenn-model: ^0.1.155
 
 dependencies:
   emoji-regex: 10.2.1
   js-yaml: 4.1.0
   react: 18.2.0
   react-dom: 18.2.0_react@18.2.0
-  zenn-content-css: 0.1.141
-  zenn-embed-elements: 0.1.141
-  zenn-markdown-html: 0.1.141
-  zenn-model: 0.1.141
+  zenn-content-css: 0.1.155
+  zenn-embed-elements: 0.1.155
+  zenn-markdown-html: 0.1.155
+  zenn-model: 0.1.155
 
 devDependencies:
   '@svgr/webpack': 6.5.1
@@ -6472,16 +6472,16 @@ packages:
     engines: {node: '>=10'}
     dev: true
 
-  /zenn-content-css/0.1.141:
-    resolution: {integrity: sha512-mvFrU9MHg9eJyJJ07iSfzGkRxlEmQZeZUMhyTDoomlnfz6A+5I2eLDbOmH5vALh399F1lyF5HwP1ci7UrQOlYg==}
+  /zenn-content-css/0.1.155:
+    resolution: {integrity: sha512-YR22ASOK/R86zPBr7fGSmuAO4urPSaAIzo0n1ZXt9MTsv5XRQuXMKWoqgvpTxE+kTrMnAREORH6IBKoy9ZOgUQ==}
     dev: false
 
-  /zenn-embed-elements/0.1.141:
-    resolution: {integrity: sha512-0Yx5jsbTNhVDhJxWh8m+F49Ycgg6dYxv1rdds/6GCQ3XiIkovm+/+gJG9Cqr0X8i5vv9CCTlIIyVP+hxaWOBgg==}
+  /zenn-embed-elements/0.1.155:
+    resolution: {integrity: sha512-mEfgvI/6Qb0A3bAV2SrPSSd3HTdgphrrQ3U4gqTdQxeecuM5xxMIV3088KvQlpJngxPDz7Z5IheLPsN95y94Eg==}
     dev: false
 
-  /zenn-markdown-html/0.1.141:
-    resolution: {integrity: sha512-dFwZJRN+DprkU1zflxcVOxRppdiSQEMsCVJt9sBQGkVQq+fI7uMCiyNXPU7DyutMF0AhC/C2ODRG1lWOTXuwKA==}
+  /zenn-markdown-html/0.1.155:
+    resolution: {integrity: sha512-VfGsyvks9fiV4SIun5bfyBtaiIC6/5wrsPMTSkVnxF6BAbcnAUF4KnwBuR+kBbYv2YXr6Q7HP4OxvWLjHmbT7g==}
     dependencies:
       '@steelydylan/markdown-it-imsize': 1.0.2
       cheerio: 1.0.0-rc.12
@@ -6498,8 +6498,8 @@ packages:
       - '@types/markdown-it'
     dev: false
 
-  /zenn-model/0.1.141:
-    resolution: {integrity: sha512-FRux+qMlpBw9asDi/xNFr3N0xfjXPx3FvtEflY8/HdhDknntVVJMgiicSaQfLeYk7cUdkWnaVw+zU1FES3OxVA==}
+  /zenn-model/0.1.155:
+    resolution: {integrity: sha512-beYw//+64bwEJz+vydk6x0tUCf6soMaOAH5HBYs369uvJzgyIDdDbnWXrL+g5FPWsG/ArQJmTPpa8yTCWN+vQA==}
     dependencies:
       emoji-regex: 10.2.1
     dev: false

--- a/src/context/editor/index.ts
+++ b/src/context/editor/index.ts
@@ -64,5 +64,30 @@ export const initializeEditor = (context: AppContext): vscode.Disposable[] => {
       // プレビューパネルを開く
       panel.reveal(void 0, true);
     }),
+
+    // エディターの表示範囲が変更されたとき（スクロールなど）
+    vscode.window.onDidChangeTextEditorVisibleRanges((event) => {
+      const editor = event.textEditor;
+      const visibleRanges = event.visibleRanges;
+
+      // 表示されている範囲の開始位置と終了位置を取得
+      visibleRanges.forEach((range) => {
+        const startLine = range.start.line;
+        const endLine = range.end.line;
+
+        const activeDocumentUri = editor.document.uri;
+        const key = cache.createKey("previewPanel", activeDocumentUri);
+        const panel = cache.getCache(key)?.panel;
+
+        if (!panel) return;
+        if (editor.viewColumn === panel.viewColumn) return;
+
+        // プレビューパネルの表示範囲を更新
+        panel.webview.postMessage({
+          type: "update-visible-ranges",
+          result: { startLine, endLine },
+        });
+      });
+    }),
   ];
 };

--- a/src/schemas/article.ts
+++ b/src/schemas/article.ts
@@ -79,15 +79,20 @@ export const createArticleContent = (
 ): ArticleContent => {
   const filename = getFilenameFromUrl(uri) || "";
 
+  const frontMatterObj = parseFrontMatter(text);
+  const frontMatterLines = Object.entries(frontMatterObj).length + 2; // 2: --- で囲まれた行数
+
   return {
     uri,
     filename,
     type: "article",
     value: {
-      ...parseFrontMatter(text),
+      ...frontMatterObj,
       slug: filename.replace(".md", ""),
     },
-    markdown: text.replace(FRONT_MATTER_PATTERN, ""),
+    markdown: text
+      // Front Matter を削除するが、ソースマップのために行数は残す
+      .replace(FRONT_MATTER_PATTERN, "\n".repeat(frontMatterLines)),
   };
 };
 

--- a/src/schemas/bookChapter.ts
+++ b/src/schemas/bookChapter.ts
@@ -67,14 +67,19 @@ export const createBookChapterContent = (
 ): BookChapterContent => {
   const filename = getFilenameFromUrl(uri) || "";
 
+  const frontMatterObj = parseFrontMatter(text);
+  const frontMatterLines = Object.entries(frontMatterObj).length + 2; // 2: --- で囲まれた行数
+
   return {
     uri,
     filename,
     type: "bookChapter",
     bookUri: getBookUriFromChapterUri(uri),
-    markdown: text.replace(FRONT_MATTER_PATTERN, ""),
+    markdown: text
+      // Front Matter を削除するが、ソースマップのために行数は残す
+      .replace(FRONT_MATTER_PATTERN, "\n".repeat(frontMatterLines)),
     value: {
-      ...parseFrontMatter(text),
+      ...frontMatterObj,
       slug:
         filename.match(/(?:\d+\.)?([^\.]+)\.md$/)?.[1] ||
         filename.replace(".md", ""),

--- a/src/types.ts
+++ b/src/types.ts
@@ -124,6 +124,10 @@ export type PreviewEvent =
       type: "open-preview-panel";
       payload: { path: string };
       result?: never;
+    }
+  | {
+      type: "update-visible-ranges";
+      result: { startLine: number; endLine: number };
     };
 
 /**

--- a/src/webviews/src/features/scrollSync.ts
+++ b/src/webviews/src/features/scrollSync.ts
@@ -1,0 +1,99 @@
+/**
+ * This implementation is based on VS Code Markdown Language Features.
+ *
+ * Ref: https://github.com/microsoft/vscode/blob/9afcef5dd1ba4e8a21988090ec299003dccfddfd/extensions/markdown-language-features/preview-src/scroll-sync.ts
+ */
+
+const codeLineClass = "code-line";
+const dataLineAttr = "data-line";
+
+type CodeLineElement = {
+  element: HTMLElement;
+  line: number;
+};
+
+/**
+ * Find the html elements that map to a specific target line in the editor.
+ *
+ * If an exact match, returns a single element. If the line is between elements,
+ * returns the element prior to and the element after the given line.
+ */
+export function getElementsForSourceLine(targetLine: number): {
+  previous: CodeLineElement;
+  next?: CodeLineElement;
+} {
+  const lineNumber = Math.floor(targetLine);
+  const elements = document.getElementsByClassName(codeLineClass);
+  const elementsArray = Array.from(elements);
+  const lines = elementsArray.map((element) => {
+    const dataLine = element.getAttribute(dataLineAttr);
+    if (!dataLine) {
+      throw new Error("codeLineClass element must have data-line attribute");
+    }
+    const line = parseInt(dataLine, 10);
+    return { element: element as HTMLElement, line };
+  });
+  let previous = lines[0] || null;
+  for (const entry of lines) {
+    if (entry.line === lineNumber) {
+      return { previous: entry, next: undefined };
+    } else if (entry.line > lineNumber) {
+      return { previous, next: entry };
+    }
+    previous = entry;
+  }
+  return { previous };
+}
+
+function getElementBounds({ element }: CodeLineElement): {
+  top: number;
+  height: number;
+} {
+  const myBounds = element.getBoundingClientRect();
+
+  // Some code line elements may contain other code line elements.
+  // In those cases, only take the height up to that child.
+  const codeLineChild = element.querySelector(`.${codeLineClass}`);
+  if (codeLineChild) {
+    const childBounds = codeLineChild.getBoundingClientRect();
+    const height = Math.max(1, childBounds.top - myBounds.top);
+    return {
+      top: myBounds.top,
+      height: height,
+    };
+  }
+
+  return myBounds;
+}
+
+/**
+ * Attempt to reveal the element for a source line in the editor.
+ */
+export function scrollToRevealSourceLine(editorLine: number) {
+  if (editorLine <= 0) {
+    window.scroll(window.scrollX, 0);
+    return;
+  }
+
+  const { previous, next } = getElementsForSourceLine(editorLine);
+  if (!previous) {
+    return;
+  }
+  let scrollTo = 0;
+  const rect = getElementBounds(previous);
+  const previousTop = rect.top;
+  if (next && next.line !== previous.line) {
+    // Between two elements. Go to percentage offset between them.
+    const betweenProgress =
+      (editorLine - previous.line) / (next.line - previous.line);
+    const previousEnd = previousTop + rect.height;
+    const betweenHeight =
+      next.element.getBoundingClientRect().top - previousEnd;
+    scrollTo = previousEnd + betweenProgress * betweenHeight;
+  } else {
+    const progressInElement = editorLine - Math.floor(editorLine);
+    scrollTo = previousTop + rect.height * progressInElement;
+  }
+  scrollTo = Math.abs(scrollTo) < 1 ? Math.sign(scrollTo) : scrollTo;
+  window.scroll(window.scrollX, Math.max(1, window.scrollY + scrollTo));
+}

--- a/src/webviews/src/index.tsx
+++ b/src/webviews/src/index.tsx
@@ -7,6 +7,7 @@ import { createRoot } from "react-dom/client";
 import { ArticlePreview } from "./components/ArticlePreview";
 import { BookChapterPreview } from "./components/BookChapterPreview";
 import { BookPreview } from "./components/BookPreview";
+import { scrollToRevealSourceLine } from "./features/scrollSync";
 import { useVSCodeApi } from "./hooks/useVSCodeApi";
 
 import { PreviewContents, PreviewEvent } from "../../types";
@@ -43,6 +44,16 @@ const App = () => {
             setContent(result);
             vscode.setState({ content: msg.result });
           }
+        }
+
+        case "update-visible-ranges": {
+          const result = msg.result;
+
+          if (result && "startLine" in result) {
+            const { startLine, endLine } = result;
+            scrollToRevealSourceLine(startLine);
+          }
+          break;
         }
       }
     };


### PR DESCRIPTION
## :bookmark_tabs: Summary

- エディター -> プレビューのスクロール同期を実装しました。
- 以下が VS Code の標準の Markdown Preview のスクロール同期機能と異なる点です。
  今回はこのスクロール同期の最初の実装ということもあり、実装はなるべくシンプルにしました。

|観点|VS Code|このPR|
|--|--|--|
| スクロール同期の方向 | エディター <-> プレビューの双方向| エディター -> プレビューの片方向のみ |
| ソース行のオフセットなど微調整 | あり | なし |
| スクロール同期する・しないの設定 | あり | なし（常に同期）|

[Screencast from 08-08-2024 12:33:16 AM.webm](https://github.com/user-attachments/assets/6f3adae2-73f5-40df-8f44-01bb8e2d95bd)

Related #1

## :clipboard: Tasks

<!-- プルリクエストを作成いただく際、お手数ですが以下の内容についてご確認をお願いします。 -->

- [x] :book: [Contribution Guide](https://github.com/zenn-dev/zenn-vscode-extension/blob/main/CONTRIBUTING.md) を読んだ
- [x] :woman_technologist: `canary` ブランチに対するプルリクエストである
- [x] 実行して正しく動作しているか確認する
- [x] 不要なコードが含まれていないか( コメントやログの消し忘れに注意 )
- [x] XSS になるようなコードが含まれていないか
- [x] Pull Reuqest の内容は妥当か( 膨らみすぎてないか )

<!-- より詳しい内容は [Pull Request Policy](https://github.com/zenn-dev/zenn-vscode-extension/blob/main/docs/pull_request_policy.md) を参照してください。 -->
