### PR TITLE
Bufferのポリフィルを追加する検証

### DIFF
--- a/package.json
+++ b/package.json
@@ -228,6 +228,7 @@
     "@vscode/test-web": "^0.0.65",
     "@vscode/vsce": "^3.2.2",
     "assert": "^2.0.0",
+    "buffer": "^6.0.3",
     "crypto-browserify": "^3.12.0",
     "css-loader": "^6.7.1",
     "esbuild-loader": "^2.19.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -75,6 +75,9 @@ importers:
       assert:
         specifier: ^2.0.0
         version: 2.1.0
+      buffer:
+        specifier: ^6.0.3
+        version: 6.0.3
       crypto-browserify:
         specifier: ^3.12.0
         version: 3.12.0
@@ -1601,6 +1604,9 @@ packages:
 
   buffer@5.7.1:
     resolution: {integrity: sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==}
+
+  buffer@6.0.3:
+    resolution: {integrity: sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==}
 
   cache-content-type@1.0.1:
     resolution: {integrity: sha512-IKufZ1o4Ut42YUrZSo8+qnMTrFuKkvyoLXUywKz9GJ5BrhOFGhLdkx9sG4KAnVvbY6kEcSFjLQul+DVmBm2bgA==}
@@ -5546,8 +5552,7 @@ snapshots:
       bare-events: 2.5.4
     optional: true
 
-  base64-js@1.5.1:
-    optional: true
+  base64-js@1.5.1: {}
 
   basic-auth@2.0.1:
     dependencies:
@@ -5651,6 +5656,11 @@ snapshots:
       base64-js: 1.5.1
       ieee754: 1.2.1
     optional: true
+
+  buffer@6.0.3:
+    dependencies:
+      base64-js: 1.5.1
+      ieee754: 1.2.1
 
   cache-content-type@1.0.1:
     dependencies:
@@ -6632,8 +6642,7 @@ snapshots:
     dependencies:
       postcss: 8.4.38
 
-  ieee754@1.2.1:
-    optional: true
+  ieee754@1.2.1: {}
 
   ignore@5.3.1: {}
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -45,6 +45,7 @@ const webExtensionConfig = {
       assert: require.resolve("assert"),
       crypto: require.resolve("crypto-browserify"),
       stream: require.resolve("stream-browserify"),
+      buffer: require.resolve("buffer/"),
     },
   },
   module: {
@@ -68,7 +69,12 @@ const webExtensionConfig = {
       },
     ],
   },
-  plugins: [new webpack.ProvidePlugin({ process: "process/browser.js" })],
+  plugins: [
+    new webpack.ProvidePlugin({ 
+      process: "process/browser.js",
+      Buffer: ["buffer", "Buffer"],
+    })
+  ],
   externals: {
     vscode: "commonjs vscode", // ignored because it doesn't exist
   },


### PR DESCRIPTION
## :bookmark_tabs: Summary

依存しているどれかのライブラリで `Buffer` が利用されはじめ、ブラウザ向けJSビルドを想定しているこの拡張機能がエラーを起こしている可能性がある。ポリフィルを追加して様子をみる。

## :clipboard: Tasks

プルリクエストを作成いただく際、お手数ですが以下の内容についてご確認をお願いします。

- [x] :book: [Contribution Guide](https://zenn-dev.github.io/zenn-docs-for-developers/contribution) を読んだ
- [x] :woman_technologist: `canary` ブランチに対するプルリクエストである
- [x] 実行して正しく動作しているか確認する
- [x] 不要なコードが含まれていないか( コメントやログの消し忘れに注意 )
- [x]  XSS になるようなコードが含まれていないか
- [x] Pull Reuqest の内容は妥当か( 膨らみすぎてないか )

より詳しい内容は [Pull Request Policy](https://github.com/zenn-dev/zenn-vscode-extension/blob/main/docs/pull_request_policy.md) を参照してください。
