### PR TITLE
記事のソート対象に、記事の作成日時、更新日時を追加。記事のソート順に昇順、降順を追加

### DIFF
--- a/package.json
+++ b/package.json
@@ -203,12 +203,25 @@
             "updated"
           ],
           "enumDescriptions": [
-            "ファイルパスの昇順で表示",
-            "タイトルの昇順で表示",
-            "作成日時の昇順で表示",
-            "更新日時の昇順で表示"
+            "ファイルパス",
+            "タイトル",
+            "作成日時",
+            "更新日時"
           ],
-          "markdownDescription": "記事の並び順を設定します。"
+          "markdownDescription": "記事をソートする基準を設定します。"
+        },
+        "zenn-preview.sortOrder": {
+          "type": "string",
+          "default": "asc",
+          "enum": [
+            "asc",
+            "desc"
+          ],
+          "enumDescriptions": [
+            "昇順",
+            "降順"
+          ],
+          "markdownDescription": "記事ソート時の `昇順/降順` を指定します。"
         }
       }
     }

--- a/package.json
+++ b/package.json
@@ -198,11 +198,15 @@
           "default": null,
           "enum": [
             null,
-            "title"
+            "title",
+            "created",
+            "updated"
           ],
           "enumDescriptions": [
             "ファイルパスの昇順で表示",
-            "タイトルの昇順で表示"
+            "タイトルの昇順で表示",
+            "作成日時の昇順で表示",
+            "更新日時の昇順で表示"
           ],
           "markdownDescription": "記事の並び順を設定します。"
         }

--- a/package.json
+++ b/package.json
@@ -199,13 +199,11 @@
           "enum": [
             null,
             "title",
-            "created",
             "updated"
           ],
           "enumDescriptions": [
             "ファイルパス",
             "タイトル",
-            "作成日時",
             "更新日時"
           ],
           "markdownDescription": "記事をソートする基準を設定します。"

--- a/src/treeview/article/articlesTreeViewProvider.ts
+++ b/src/treeview/article/articlesTreeViewProvider.ts
@@ -48,7 +48,7 @@ export class ArticlesTreeViewProvider implements TreeDataProvider {
 
       this.treeItems = treeItems;
 
-      return PreviewTreeItem.sortTreeItems(treeItems);
+      return await PreviewTreeItem.sortTreeItems(treeItems);
     } catch {
       console.error("articlesフォルダ内にコンテンツが見つかりませんでした");
       return [];

--- a/src/treeview/book/bookTreeItem.ts
+++ b/src/treeview/book/bookTreeItem.ts
@@ -63,7 +63,7 @@ export class BookTreeItem extends PreviewTreeItem {
       .get<boolean>("sortByChapterNumber");
     const sortedItems = isSortedByChapterNumber
       ? chapterTreeItems
-      : PreviewTreeItem.sortTreeItems(chapterTreeItems);
+      : await PreviewTreeItem.sortTreeItems(chapterTreeItems);
 
     const treeItems = [
       // 設定ファイルのTreeItem

--- a/src/treeview/book/booksTreeViewProvider.ts
+++ b/src/treeview/book/booksTreeViewProvider.ts
@@ -49,7 +49,7 @@ export class BooksTreeViewProvider implements TreeDataProvider {
 
       this.treeItems = treeItems;
 
-      return PreviewTreeItem.sortTreeItems(treeItems);
+      return await PreviewTreeItem.sortTreeItems(treeItems);
     } catch {
       console.error("booksフォルダ内にコンテンツが見つかりませんでした");
       return [];

--- a/src/treeview/previewTreeItem.ts
+++ b/src/treeview/previewTreeItem.ts
@@ -72,8 +72,8 @@ export abstract class PreviewTreeItem extends vscode.TreeItem {
     const sortOrder = zennPreviewConfig.get<string>("sortOrder");
     const order = sortOrder === "asc" ? 1 : -1;
 
-    // 作成日時あるいは更新日時でソート
-    if (sortArticle === "created" || sortArticle === "updated") {
+    // 更新日時でソート
+    if (sortArticle === "updated") {
       const statsPromises = items.map(async (item) => {
         if (item.contentUri) {
           try {
@@ -94,18 +94,13 @@ export abstract class PreviewTreeItem extends vscode.TreeItem {
         const bStat = statsMap.get(b.path);
 
         if (aStat && bStat) {
-          // created
-          if (sortArticle === "created") {
-            return (aStat.ctime - bStat.ctime) * order;
-          } 
-          // updated
-          else {
-            return (aStat.mtime - bStat.mtime) * order;
-          }
+          return (aStat.mtime - bStat.mtime) * order;
         }
 
-        // ファイルの作成・更新時刻が取れなかった場合はpathで比較
-        return a.path.localeCompare(b.path, "ja", { sensitivity: "base" }) * order;
+        // ファイルの更新時刻が取れなかった場合はpathで比較
+        return (
+          a.path.localeCompare(b.path, "ja", { sensitivity: "base" }) * order
+        );
       });
     }
 
@@ -136,12 +131,16 @@ export abstract class PreviewTreeItem extends vscode.TreeItem {
         }
 
         // 絵文字除去後ラベルが両方空の場合はpathで比較 (元々ラベルがなかった場合など)
-        return a.path.localeCompare(b.path, "ja", { sensitivity: "base" }) * order;
+        return (
+          a.path.localeCompare(b.path, "ja", { sensitivity: "base" }) * order
+        );
       }
 
       // ファイルパスでソート
       else {
-        return a.path.localeCompare(b.path, "ja", { sensitivity: "base" }) * order;
+        return (
+          a.path.localeCompare(b.path, "ja", { sensitivity: "base" }) * order
+        );
       }
     });
   }


### PR DESCRIPTION
## :bookmark_tabs: Summary

記事の作成日時、更新日時でソートしたかったので追加しました。日時ソート時は降順でソートさせたかったのでソート順も指定できる様にしました。

記事のソート対象として
- 記事の作成日時
- 更新日時

を追加しました。

また、記事のソート順を追加し
- 昇順
- 降順

を選択できるようにしました。

<img width="1450" height="1448" alt="image" src="https://github.com/user-attachments/assets/136f5cf8-86d1-4542-81a2-96be727a1f11" />

<img width="1450" height="1448" alt="image" src="https://github.com/user-attachments/assets/a7e2619a-9f22-4558-8d94-fef6c8eaeba7" />


## :clipboard: Tasks

プルリクエストを作成いただく際、お手数ですが以下の内容についてご確認をお願いします。

- [x] :book: [Contribution Guide](https://zenn-dev.github.io/zenn-docs-for-developers/contribution) を読んだ
- [x] :woman_technologist: `canary` ブランチに対するプルリクエストである
- [x] 実行して正しく動作しているか確認する
- [x] 不要なコードが含まれていないか( コメントやログの消し忘れに注意 )
- [x] XSS になるようなコードが含まれていないか
- [x] Pull Reuqest の内容は妥当か( 膨らみすぎてないか )

より詳しい内容は [Pull Request Policy](https://github.com/zenn-dev/zenn-vscode-extension/blob/main/docs/pull_request_policy.md) を参照してください。
