### PR TITLE
.vscode/settings.json に jsonのインデントをスペース2設定を追加

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -11,5 +11,9 @@
     "out": true // set this to false to include "out" folder in search results
   },
   // Turn off tsc task auto detection since we have the necessary tasks as npm scripts
-  "typescript.tsc.autoDetect": "off"
+  "typescript.tsc.autoDetect": "off",
+
+  "[json]": {
+    "editor.tabSize": 2
+  }
 }


### PR DESCRIPTION
## :bookmark_tabs: Summary

.vscode/settings.jsonにjsonのインデントをスペース2個とするルールを追加しました。
以前以下で指摘をもらったところですが、VSCodeで自動フォーマットできたほうが良いと思うので、プロジェクトの設定に追加しました。

- https://github.com/zenn-dev/zenn-vscode-extension/pull/123#issuecomment-2974926456

## :clipboard: Tasks

プルリクエストを作成いただく際、お手数ですが以下の内容についてご確認をお願いします。

- [x] :book: [Contribution Guide](https://zenn-dev.github.io/zenn-docs-for-developers/contribution) を読んだ
- [x] :woman_technologist: `canary` ブランチに対するプルリクエストである
- [x] 実行して正しく動作しているか確認する
- [x] 不要なコードが含まれていないか( コメントやログの消し忘れに注意 )
- [x] XSS になるようなコードが含まれていないか
- [x] Pull Reuqest の内容は妥当か( 膨らみすぎてないか )

より詳しい内容は [Pull Request Policy](https://github.com/zenn-dev/zenn-vscode-extension/blob/main/docs/pull_request_policy.md) を参照してください。
