### PR TITLE
Add dark mode support for preview

### DIFF
--- a/src/utils/panel.ts
+++ b/src/utils/panel.ts
@@ -16,6 +16,7 @@ export const createWebviewHtml = (webviewSrc: vscode.Uri) => {
     `  <head>` +
     `    <meta charset="utf-8">` +
     `    <meta name="viewport" content="width=device-width,initial-scale=1.0">` +
+    `    <meta name="color-scheme" content="light dark">` +
     `    <title>Zenn Preview</title>` +
     `    <!-- 埋め込み要素のイベントを処理するためのスクリプト -->` +
     `    <script src="https://embed.zenn.studio/js/listen-embed-event.js"></script>` +

--- a/src/webviews/src/components/ArticlePreview/ArticlePreview.module.scss
+++ b/src/webviews/src/components/ArticlePreview/ArticlePreview.module.scss
@@ -12,7 +12,7 @@
 .emoji {
   margin-top: -0.5em;
   font-size: 56px;
-  color: #000;
+  color: var(--c-body);
 }
 
 .title {
@@ -48,7 +48,7 @@
   color: var(--c-gray);
   font-size: 0.9em;
   border: solid 1px var(--c-gray-border);
-  background: #fff;
+  background: var(--c-bg-page);
   padding: 0.1em 0.4em;
   border-radius: 5px;
   margin: 3px 6px 3px 0;

--- a/src/webviews/src/components/BookChapterPreview/BookChapterPreview.module.scss
+++ b/src/webviews/src/components/BookChapterPreview/BookChapterPreview.module.scss
@@ -14,7 +14,7 @@
 }
 
 .bookNavi {
-  background: rgb(213 225 234);
+  background: var(--c-nav-bg);
   padding: 0.6rem 1rem;
 }
 

--- a/src/webviews/src/components/BookPreview/BookPreview.module.scss
+++ b/src/webviews/src/components/BookPreview/BookPreview.module.scss
@@ -15,7 +15,7 @@
 }
 
 .coverImage {
-  background: #fff;
+  background: var(--c-bg-page);
   object-fit: cover;
   box-shadow: 0 9px 20px -9px rgb(0 27 68 / 52%), 0 0 3px rgb(0 21 60 / 10%);
   border-radius: 5px;
@@ -57,7 +57,7 @@
   color: var(--c-gray);
   font-size: 0.9em;
   border: solid 1px var(--c-gray-border);
-  background: #fff;
+  background: var(--c-bg-page);
   padding: 0.1em 0.4em;
   border-radius: 5px;
   margin: 3px 6px 3px 0;

--- a/src/webviews/src/components/ValidationErrors/ValidationErrors.module.scss
+++ b/src/webviews/src/components/ValidationErrors/ValidationErrors.module.scss
@@ -24,7 +24,7 @@
 
 .warningTitle {
   font-size: 0.95rem;
-  color: #ff9715;
+  color: var(--c-warning);
   font-weight: 700;
 }
 

--- a/src/webviews/src/components/ValidationErrors/ValidationErrors.module.scss
+++ b/src/webviews/src/components/ValidationErrors/ValidationErrors.module.scss
@@ -1,6 +1,6 @@
 .validationError {
   padding: 1.2rem 1.4rem 1.3rem;
-  background: #fff;
+  background: var(--c-bg-page);
   border-radius: 10px;
 }
 
@@ -12,7 +12,7 @@
 
 .warnings {
   .errorIcon {
-    color: #ff9715;
+    color: var(--c-warning);
   }
 }
 

--- a/src/webviews/src/index.tsx
+++ b/src/webviews/src/index.tsx
@@ -22,6 +22,23 @@ const App = () => {
     import("zenn-embed-elements");
   }, []);
 
+  // VSCodeのテーマに合わせてdata-theme属性を設定する
+  // VSCode webviewはbodyに vscode-dark / vscode-light クラスを付与するため、
+  // MutationObserverでクラスの変化を監視する
+  useEffect(() => {
+    const applyTheme = () => {
+      const isDark = document.body.classList.contains("vscode-dark");
+      const theme = isDark ? "dark" : "light";
+      document.documentElement.setAttribute("data-theme", theme);
+      document.documentElement.style.colorScheme = theme;
+    };
+    applyTheme();
+
+    const observer = new MutationObserver(applyTheme);
+    observer.observe(document.body, { attributes: true, attributeFilter: ["class"] });
+    return () => observer.disconnect();
+  }, []);
+
   useEffect(() => {
     const onMessage = (event: MessageEvent) => {
       const msg = event.data as PreviewEvent;

--- a/src/webviews/src/index.tsx
+++ b/src/webviews/src/index.tsx
@@ -27,7 +27,8 @@ const App = () => {
   // MutationObserverでクラスの変化を監視する
   useEffect(() => {
     const applyTheme = () => {
-      const isDark = document.body.classList.contains("vscode-dark");
+      const isDark = document.body.classList.contains("vscode-dark") ||
+        document.body.classList.contains("vscode-high-contrast");
       const theme = isDark ? "dark" : "light";
       document.documentElement.setAttribute("data-theme", theme);
       document.documentElement.style.colorScheme = theme;

--- a/src/webviews/src/styles/index.scss
+++ b/src/webviews/src/styles/index.scss
@@ -9,6 +9,9 @@
   --c-gray-bg: #edf2f7;
   --c-error: #fa5d5d;
   --c-error-bg: #fff0f0;
+  --c-bg-page: #ffffff;
+  --c-nav-bg: rgb(213 225 234);
+  --c-warning: #ff9715;
   /* Font */
   --font-base: -apple-system, "BlinkMacSystemFont", "Hiragino Kaku Gothic ProN",
     "Hiragino Sans", Meiryo, sans-serif, "Segoe UI Emoji";
@@ -16,8 +19,23 @@
     "Segoe UI Emoji";
 }
 
+[data-theme^="dark"] {
+  --c-primary: #3ea8ff;
+  --c-primary-darker: #0f93ff;
+  --c-primary-bg: #1a2f44;
+  --c-body: rgba(255, 255, 255, 0.85);
+  --c-gray: #9ba3ab;
+  --c-gray-border: #2d3741;
+  --c-gray-bg: #1e2a35;
+  --c-error: #ff6b6b;
+  --c-error-bg: #311818;
+  --c-bg-page: #0d1117;
+  --c-nav-bg: #161b22;
+  --c-warning: #e5a21a;
+}
+
 html {
-  background: white;
+  background: var(--c-bg-page);
   box-sizing: border-box;
   font-size: 16px;
   -ms-text-size-adjust: 100%;

--- a/src/webviews/src/styles/index.scss
+++ b/src/webviews/src/styles/index.scss
@@ -29,7 +29,7 @@
   --c-gray-bg: #1e2a35;
   --c-error: #ff6b6b;
   --c-error-bg: #311818;
-  --c-bg-page: #0d1117;
+  --c-bg-page: #0d223a;
   --c-nav-bg: #161b22;
   --c-warning: #e5a21a;
 }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -70,10 +70,17 @@ const webExtensionConfig = {
     ],
   },
   plugins: [
-    new webpack.ProvidePlugin({ 
+    new webpack.ProvidePlugin({
       process: "process/browser.js",
       Buffer: ["buffer", "Buffer"],
-    })
+    }),
+    // webworker環境でもブラウザとして認識させる（Shikiがブラウザ用JSエンジンを使うために必要）
+    new webpack.DefinePlugin({
+      "typeof window": JSON.stringify("object"),
+    }),
+    // Shikiの言語文法を個別チャンクに分割させず、メインバンドルに統合する
+    // webworker環境では動的チャンクをロードできないため必要
+    new webpack.optimize.LimitChunkCountPlugin({ maxChunks: 1 }),
   ],
   externals: {
     vscode: "commonjs vscode", // ignored because it doesn't exist


### PR DESCRIPTION
## Summary
- VSCodeのテーマ（ライト/ダーク）に連動してプレビューの配色を自動切り替え
- `zenn-content-css` 0.4.5 の `[data-theme^=dark]` セレクタによる既存ダークモード対応を活用
- 各コンポーネントのハードコード色（`#000`, `#fff`, `rgb(213 225 234)` 等）をCSS変数に置き換え
- Shiki シンタックスハイライトを webworker 環境で動作するよう修正

## 変更ファイル
- `src/utils/panel.ts` — `color-scheme` メタタグ追加
- `src/webviews/src/index.tsx` — テーマ検出・`data-theme`/`color-scheme` 設定
- `src/webviews/src/styles/index.scss` — ダークモード用CSS変数定義
- `*.module.scss` (4ファイル) — ハードコード色をCSS変数に置き換え
- `webpack.config.js` — Shiki の webworker 対応（`DefinePlugin` + `LimitChunkCountPlugin`）

## Test plan
- [x] `pnpm run compile-web` でビルド成功を確認
- [x] `pnpm run lint:tsc` で型チェック成功を確認
- [x] `pnpm dev` でライトテーマ時の表示を確認
- [x] ダークテーマに切り替えてプレビューが暗い配色に変わることを確認
- [x] スクロールバーの色がテーマに追従することを確認
- [x] シンタックスハイライトが機能することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)